### PR TITLE
Fix to timing statistics collection

### DIFF
--- a/src/time_p.f90
+++ b/src/time_p.f90
@@ -2304,12 +2304,12 @@ KMAXE=XMPIELRANK(N)
         
 
     IF (statistics.eq.1)THEN
-    !$OMP BARRIER
-    !$OMP MASTER
-    pr_t3=MPI_Wtime()
-    prace_t2=pr_t3-pr_t2
-    !$OMP END MASTER
-     !$OMP BARRIER
+      !$OMP BARRIER
+      !$OMP MASTER
+      pr_t3=MPI_Wtime()
+      prace_t2=pr_t3-pr_t2
+      !$OMP END MASTER
+      !$OMP BARRIER
     END IF
 
 
@@ -2334,6 +2334,15 @@ KMAXE=XMPIELRANK(N)
         CALL TROUBLE_INDICATOR2 ! Changes DG to FV
 
     end if
+
+    IF (statistics.eq.1)THEN
+      !$OMP BARRIER
+      !$OMP MASTER
+      pr_t4=MPI_Wtime()
+      prace_t3=pr_t4-pr_t3
+      !$OMP END MASTER
+      !$OMP BARRIER
+    END IF
 
     CALL EXHBOUNDHIGHER(N)
 
@@ -2363,19 +2372,6 @@ KMAXE=XMPIELRANK(N)
 
     end if
     
-     IF (statistics.eq.1)THEN
-    !$OMP BARRIER
-    !$OMP MASTER
-    pr_t4=MPI_Wtime()
-    prace_t3=pr_t4-pr_t3
-    !$OMP END MASTER
-     !$OMP BARRIER
-    END IF
-
-
-
-
-
 
     IF (statistics.eq.1)THEN
     !$OMP BARRIER


### PR DESCRIPTION
T_BOUND/prace_t4 doesn't look like it is capturing the timing of exchange of boundary extrapolated values. The time recording should be moved to capture it and separate it from T_RECON/prace_t3.